### PR TITLE
Insert an optional "label" tag before the "select" tag

### DIFF
--- a/tinynav.js
+++ b/tinynav.js
@@ -5,7 +5,7 @@
     // Default settings
     var settings = $.extend({
       'active' : 'selected', // String: Set the "active" class
-      'header' : '' // String: Specify text for "header" and show header instead of the active item
+      'header' : '', // String: Specify text for "header" and show header instead of the active item
       'label'  : '' // String: sets the <label> text for the <select>
     }, options);
 
@@ -65,11 +65,11 @@
 
         // Inject label
         if  (settings.label !== '') {
-          $select.before( 
+          $select.before(
             $("<label/>")
               .attr("for", namespace_i)
               .addClass(namespace + ' ' + namespace_i)
-              .append(settings.label);
+              .append(settings.label)
           );
         }
 


### PR DESCRIPTION
To make the select more accessible, it helps to add a label tag.  I added it as another option in the settings object.

Use the option like this:

```
jQuery(".menu").tinyNav({ label: 'Table of Contents' });
```

which creates HTML that looks something like this:

```
<label class="tinynav tinynav1" for="tinynav1">Table of Contents</label>
<select id="tinynav1" class="tinynav tinynav1">
    <option value="...">...</option>
    ...
</select>
```
