### PR TITLE
Specify depth of navigation

### DIFF
--- a/tinynav.js
+++ b/tinynav.js
@@ -52,10 +52,20 @@
 
         // Select the active item
         if (!settings.header) {
-          $select
-            .find(':eq(' + $(l_namespace_i + ' li')
-            .index($(l_namespace_i + ' li.' + settings.active)) + ')')
-            .attr('selected', true);
+            $($select.find("option").get().reverse()).each(function(){
+                if($(this).attr("value") == $('ul.' + l_namespace_i + ' li.' + settings.active + ' a').attr("href")){
+                    $(this).attr('selected', true);
+                    return false;
+                }
+                var nextItem = $('ul.' + l_namespace_i + ' li.' + settings.active);
+                while(nextItem.parents("li").length > 0){
+                    nextItem = nextItem.parents("li");
+                    if($(this).attr("value") == nextItem.children('a').attr("href")){
+                        $(this).attr('selected', true);
+                        return false;
+                    }
+                }
+            });
         }
 
         // Change window location


### PR DESCRIPTION
I have been working on a project that has a mega menu and also a side menu.  Because of the duplicate navigation I only wanted the top navigation to show the first level of nav once its made into a select.  The alterations in this pull request add another settings key "depth" which allows the developer to set a specific depth to iterate to.

An example:

``` js
$(".navigation_one > ul").tinyNav({
  active: 'current',
  depth: 2
});
```
