### PR TITLE
Limit a link's parents 'ul, ol' inside tinyNav scope

### DIFF
--- a/tinynav.js
+++ b/tinynav.js
@@ -38,7 +38,7 @@
           .each(function () {
             options += '<option value="' + $(this).attr('href') + '">';
             var j;
-            for (j = 0; j < $(this).parents('ul, ol').length - 1; j++) {
+            for (j = 0; j < $(this).parentsUntil('.l_'+ namespace_i, 'ul, ol').length; j++) {
               options += '- ';
             }
             options += $(this).text() + '</option>';


### PR DESCRIPTION
Limit 'a' link's parents 'ul, ol' inside TinyNav scope, such TinyNav will function correctly when inside other 'ul, ol'

Like this:

```
<ul><!-- TinyNav wrapped in a 'ul' -->
    <ul class="tinyNav">
      <li class="selected"><a href="demo.html">Demo page</a></li>
      <li><a href="http://bing.com">Bing</a> </li>
      <li><a href="http://yahoo.com">Yahoo</a></li>
    </ul>
</ul>
```
